### PR TITLE
Improve robustness when DNS is unreliable

### DIFF
--- a/custom_components/aredn_node/api.py
+++ b/custom_components/aredn_node/api.py
@@ -36,11 +36,12 @@ class ArednNodeApiClient:
         self._host = host
         self._session = session
 
-    async def async_get_data(self) -> Any:
+    async def async_get_data(self, host: str | None = None) -> Any:
         """Get data from the API."""
+        target_host = host or self._host
         return await self._api_wrapper(
             method="get",
-            url=f"http://{self._host}/a/sysinfo?nodes=1&link_info=1",
+            url=f"http://{target_host}/a/sysinfo?nodes=1&link_info=1",
         )
 
     async def _api_wrapper(

--- a/custom_components/aredn_node/coordinator.py
+++ b/custom_components/aredn_node/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -17,10 +18,35 @@ class ArednNodeDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
     config_entry: ArednNodeConfigEntry
+    _cached_ip: str | None = None
+
+    @property
+    def cached_ip(self) -> str | None:
+        """Return the cached IP address."""
+        return self._cached_ip
+
+    async def _async_resolve_host(self, host: str) -> str | None:
+        """Resolve hostname to IP address."""
+        try:
+            return await self.hass.async_add_executor_job(socket.gethostbyname, host)
+        except OSError:
+            return None
 
     async def _async_update_data(self) -> Any:
         """Update data via library."""
+        client = self.config_entry.runtime_data.client
+        host = self.config_entry.data["host"]
+
+        resolved_ip = await self._async_resolve_host(host)
+        target_host = host
+
+        if resolved_ip:
+            self._cached_ip = resolved_ip
+            target_host = resolved_ip
+        elif self._cached_ip:
+            target_host = self._cached_ip
+
         try:
-            return await self.config_entry.runtime_data.client.async_get_data()
+            return await client.async_get_data(host=target_host)
         except ArednNodeApiClientError as exception:
             raise UpdateFailed(exception) from exception

--- a/custom_components/aredn_node/sensor.py
+++ b/custom_components/aredn_node/sensor.py
@@ -236,6 +236,7 @@ async def async_setup_entry(
     )
 
     entities.append(ArednNodeBootTimeSensor(coordinator=coordinator))
+    entities.append(ArednNodeCachedIPSensor(coordinator=coordinator))
 
     # Dynamically create sensors for each link type
     link_types = set()
@@ -432,6 +433,25 @@ class ArednNodeBootTimeSensor(ArednNodeEntity, SensorEntity):
 
         # Otherwise, keep the existing value.
         return self._last_boot_time
+
+
+class ArednNodeCachedIPSensor(ArednNodeEntity, SensorEntity):
+    """AREDN Node cached IP sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:ip-network"
+
+    def __init__(self, coordinator: ArednNodeDataUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        node_name = coordinator.data.get("node")
+        self._attr_name = f"{node_name} IP"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-ip"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor."""
+        return self.coordinator.cached_ip
 
 
 RF_PEER_SENSOR_DESCRIPTIONS: tuple[ArednNodeSensorEntityDescription, ...] = (


### PR DESCRIPTION
Since DNS resolution on AREDN can sometimes be spotty, resolve the hostname ourselves and cache the IP address. If DNS lookup for a node fails when it's time to update, fall back to that cached IP address so we stay in contact with the node. Also expose a sensor to show that resolved IP address.

On my instance, in which AREDN is on a separate VLAN, I've had issues with the systemd-resolved proxy getting confused and failing hostname lookups for AREDN nodes, resulting in that node appearing unavailable in this integration. Hopefully this will help, as the network is actually still reachable.